### PR TITLE
sdcicd-1285 added param to gate template for namespace-unique object names

### DIFF
--- a/hack/gating-test.yaml
+++ b/hack/gating-test.yaml
@@ -2,6 +2,9 @@ apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: managed-release-bundle-gate-job-template
+parameters:
+- name: JOB_NAME
+  value: "none"
 objects:
 - apiVersion: batch/v1
   kind: Job
@@ -11,7 +14,7 @@ objects:
     template:
       spec:
         containers:
-        - name: test
+        - name: test-${JOB_NAME}
           image: quay.io/app-sre/ubi8-ubi-minimal:latest
           command: ["sh", "-c", "exit 0"]
           securityContext:


### PR DESCRIPTION
- adds JOB_NAME template param to be provided by app-interface jobs. This should keep the object name unique in the appinterface namespace where multiple gate jobs run. 