### PR TITLE
sdcicd-1285 adds standard JOBID param for job name creation

### DIFF
--- a/hack/gating-test.yaml
+++ b/hack/gating-test.yaml
@@ -3,13 +3,16 @@ kind: Template
 metadata:
   name: managed-release-bundle-gate-job-template
 parameters:
+- name: JOBID
+  generate: expression
+  from: "[0-9a-z]{7}"
 - name: JOB_NAME
   value: "none"
 objects:
 - apiVersion: batch/v1
   kind: Job
   metadata:
-    name: managed-release-bundle-gate-${JOB_NAME}
+    name: managed-release-bundle-gate-${JOBID}
   spec:
     template:
       spec:


### PR DESCRIPTION
This and IMAGE_TAG are the only params allowed to generate job name