### PR TITLE
hack: look up digest for latest registry image

### DIFF
--- a/hack/update-operator-release.sh
+++ b/hack/update-operator-release.sh
@@ -65,13 +65,9 @@ fi
 _OUTDIR=resources/${OPERATOR_NAME}
 rm -rf "${_OUTDIR}" && mkdir -p "${_OUTDIR}"
 
-# TODO: determine this
-_OPERATOR_OLM_CHANNEL=staging
-_OPERATOR_OLM_REGISTRY_IMAGE_TAG="${_OPERATOR_OLM_CHANNEL}-latest"
-
 # look up the digest for the new registry image
 _OPERATOR_OLM_REGISTRY_IMAGE_DIGEST=$(${SKOPEO} inspect --format '{{.Digest}}' \
-	docker://"${OPERATOR_OLM_REGISTRY_IMAGE}":"${_OPERATOR_OLM_REGISTRY_IMAGE_TAG}" |
+	docker://"${OPERATOR_OLM_REGISTRY_IMAGE}":"${OPERATOR_VERSION}" |
 	tr -d "\r")
 
 log "Processing template with parameters..."


### PR DESCRIPTION
the image isn't `stable-latest` it is instead the version of the operator

(v4.16.139-c3b18d3)